### PR TITLE
Set up files for cutting new gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
+group :deployment do
+  gem 'package_cloud'
+  gem 'rake'
+end
+
 gemspec

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,4 @@
+deploy:
+  override:
+    - bundle exec rake build
+    - bundle exec package_cloud push shopify/gems pkg/*.gem

--- a/socksify.gemspec
+++ b/socksify.gemspec
@@ -4,7 +4,7 @@ require 'rubygems'
 
 spec = Gem::Specification.new do |s|
   s.name = 'socksify'
-  s.version = "1.7.1"
+  s.version = "2.0.0"
   s.summary = "Redirect all TCPSockets through a SOCKS5 proxy"
   s.authors = ["Stephan Maka", "Andrey Kouznetsov", "Christopher Thorpe", "Musy Bite", "Yuichi Tateno", "David Dollar"]
   s.licenses = ['Ruby', 'GPL-3.0']


### PR DESCRIPTION
Adding shipit.yml file and incrementing major gem version as the new dependency on Ruby 2.0.0+ is a backwards-incompatible change.